### PR TITLE
bookmark_utils: skip over None when merging bookmarks

### DIFF
--- a/firefox_bookmarks_merger/bookmark_utils.py
+++ b/firefox_bookmarks_merger/bookmark_utils.py
@@ -53,8 +53,9 @@ def merge_into_bookmarks(main_bookmarks, bookmarks):
         if has_duplicate(main_bookmarks, bookmark):
             remove_from_tree(bookmarks, bookmark)
     strip_ids(bookmarks)
-    for bookmark in bookmarks:
-        main_bookmarks.append(bookmark)
+    if bookmarks:
+        for bookmark in bookmarks:
+            main_bookmarks.append(bookmark)
 
 def merge_into(main_bookmarks_object, other_bookmarks_object):
     merge_into_bookmarks(


### PR DESCRIPTION
If a bookmark category is empty then merge_bookmarks() recieves None and
hits a traceback when trying to loop over the bookmarks to merge.
Skip these entries so that the merge can succeed.